### PR TITLE
Fix broken links in Placeholders and Accessibility pages

### DIFF
--- a/docs/_docs/accessibility.md
+++ b/docs/_docs/accessibility.md
@@ -2,7 +2,7 @@
 title: Accessibility
 layout: docs
 permalink: /docs/accessibility.html
-prevPage: image-modification-block.html
+prevPage: placeholder-fade-duration.html
 nextPage: layer-backing.html
 ---
 

--- a/docs/_docs/placeholder-fade-duration.md
+++ b/docs/_docs/placeholder-fade-duration.md
@@ -19,7 +19,7 @@ The <code>-placeholderImage</code> function may be called on a background thread
 
 An ideal resource for creating placeholder images, including rounded rect solid colored ones or simple square corner ones is the UIImage+ASConvience category methods in ASDK.
 
-See our ancient <a href="https://github.com/facebook/AsyncDisplayKit/tree/master/examples_extra/placeholders">Placeholders sample app</a> to see this concept, first invented by the Facebook Paper team, in action. 
+See our ancient <a href="https://github.com/facebook/AsyncDisplayKit/tree/master/examples_extra/Placeholders">Placeholders sample app</a> to see this concept, first invented by the Facebook Paper team, in action. 
 
 ## `.neverShowPlaceholders`
 


### PR DESCRIPTION
Btw, I'm in AsyncDisplayKit organization but somehow don't have the permission to push directly to this repo (hence the fork). Any idea why?