### PR TITLE
Swift examples

### DIFF
--- a/docs/_docs/automatic-layout-containers.md
+++ b/docs/_docs/automatic-layout-containers.md
@@ -8,12 +8,11 @@ nextPage: layout-api-debugging.html
 
 AsyncDisplayKit includes a library of `layoutSpec` components that can be composed to declaratively specify a layout. 
 
-The **child(ren) of a layoutSpec may be a node, a layoutSpec or a combination of the two types.**  In the below image, an ASStackLayoutSpec (vertical) containing a text node and an image node, is wrapped in another ASStackLayoutSpec (horizontal) with another text node. 
+The **child(ren) of a layoutSpec may be a node, a layoutSpec or a combination of the two types.**  In the below image, an `ASStackLayoutSpec` (vertical) containing a text node and an image node, is wrapped in another `ASStackLayoutSpec` (horizontal) with another text node. 
 
 <img src="/static/images/layoutable-types.png">
 
-Both nodes and layoutSpecs conform to the `<ASLayoutable>` protocol.  Any `ASLayoutable` object may be the child of a layoutSpec. <a href = "automatic-layout-containers.html#aslayoutable-properties">ASLayoutable properties</a> may be applied to ASLayoutable objects to create complex UI designs. 
-
+Both nodes and layoutSpecs conform to the `<ASLayoutable>` protocol.  Any `ASLayoutable` object may be the child of a layoutSpec. <a href = "automatic-layout-containers.html#aslayoutable-properties">ASLayoutable properties</a> may be applied to `ASLayoutable` objects to create complex UI designs. 
 
 ### Single Child layoutSpecs
 
@@ -24,9 +23,9 @@ Both nodes and layoutSpecs conform to the `<ASLayoutable>` protocol.  Any `ASLay
   </tr>
   <tr>
     <td><b><code>ASInsetLayoutSpec</code></b></td>
-    <td><p>Applies an inset margin around a component.</p> <p><i>The object that is being inset must have an intrinsic size.</i></p></td> 
+    <td><p>Applies an inset margin around a component.</p> <p><i>The object that is being inset must have an intrinsic size.</i></p></td>
   </tr>
-    <tr>
+  <tr>
     <td><b><code>ASOverlayLayoutSpec</code></b></td>
     <td><p>Lays out a component, stretching another component on top of it as an overlay.</p> <p><i>The underlay object must have an intrinsic size. Additionally, the order in which subnodes are added matters for this layoutSpec; the overlay object must be added as a subnode to the parent node after the underlay object.</i></p></td> 
   </tr>
@@ -40,7 +39,7 @@ Both nodes and layoutSpecs conform to the `<ASLayoutable>` protocol.  Any `ASLay
   </tr>
   <tr>
     <td><b><code>ASRatioLayoutSpec</code></b></td>
-    <td><p>Lays out a component at a fixed aspect ratio (which can be scaled).</p> <p><i>This spec is great for objects that do not have an intrinisic size, such as ASNetworkImageNodes and ASVideoNodes.</p> </td> 
+    <td><p>Lays out a component at a fixed aspect ratio (which can be scaled).</p> <p><i>This spec is great for objects that do not have an intrinisic size, such as ASNetworkImageNodes and ASVideoNodes.</i></p> </td> 
   </tr>
   <tr>
     <td><b><code>ASRelativeLayoutSpec</code></b></td>
@@ -110,7 +109,7 @@ The following properties may be set on any node or layoutSpecs, but will only ap
   </tr>
   <tr>
     <td><b><code>CGFloat .ascender</code></b></td>
-    <td>Used for baseline alignment. The distance from the top of the object to its baseline./td> 
+    <td>Used for baseline alignment. The distance from the top of the object to its baseline.</td> 
   </tr>
   <tr>
     <td><b><code>CGFloat .descender</code></b></td>
@@ -144,37 +143,36 @@ AsyncDisplayKit's layout is recursive, starting at the layoutSpec returned from 
 Some leaf nodes provide their own intrinsic size, such as ASTextNode or ASImageNode. An attributed string or an image have their own sizes. Other leaf nodes require an intrinsic size to be set.
 
 **Nodes that require the developer to provide an intrinsic size:**
-<ul>
-  <li>`ASDisplayNode` custom subclasses may provide their intrinisc size by implementing `calculateSizeThatFits:`.</li>
-  <li>`ASNetworkImageNode` or `ASMultiplexImageNode` have no intrinsic size until the image is downloaded.</li>
-  <li>`ASVideoNode` or `ASVideoNodePlayer` have no intrinsic size until the video is downloaded.</li>
-</ul>
+
+ - `ASDisplayNode` custom subclasses may provide their intrinisc size by implementing `calculateSizeThatFits:`.
+ - `ASNetworkImageNode` or `ASMultiplexImageNode` have no intrinsic size until the image is downloaded.
+ - `ASVideoNode` or `ASVideoNodePlayer` have no intrinsic size until the video is downloaded.
+
 
 To provide an intrinisc size for these nodes, you can set one of the following:
-<ol>
-  <li>implement `calculateSizeThatFits:` for **custom ASDisplayNode subclasses** only.</li>
-  <li>set `.preferredFrameSize`</li>
-  <li>set `.sizeRange` for children of **static** nodes only.</li>
-</ol>
+
+  1. implement `calculateSizeThatFits:` for **custom ASDisplayNode subclasses** only.
+  2. set `.preferredFrameSize`
+  3. set `.sizeRange` for children of **static** nodes only.
+
 
 Note that `.preferredFrameSize` is not considered by `ASTextNodes`. Also, setting .sizeRange on a node will override the node's intrinisic size provided by `calculateSizeThatFits:`. 
 
 ### Common Confusions
 
 There are two main confusions that developers have when using layoutSpecs
-<ol>
-  <li>Certain ASLayoutable properties only apply to children of stack nodes, while other properties only apply to children of static nodes. All ASLayoutable properties can be applied to any node or layoutSpec, however certain properties will only take effect depending on the type of the parent layoutSpec they are wrapped in. These differences are highlighted above in the ASStackLayoutable Properties and ASStaticLayoutable Properties sections. </li>
-  <li>Have I set an intrinsic size for all of my leaf nodes?</li>
-</ol>
+
+  1. Certain ASLayoutable properties only apply to children of stack nodes, while other properties only apply to children of static nodes. All ASLayoutable properties can be applied to any node or layoutSpec, however certain properties will only take effect depending on the type of the parent layoutSpec they are wrapped in. These differences are highlighted above in the ASStackLayoutable Properties and ASStaticLayoutable Properties sections.
+  2. Have I set an intrinsic size for all of my leaf nodes?
+
 
 #### I set `.flexGrow` on my node, but it doesn't grow?
 
 Upward propogation of ASLayoutable properties is currently disabled. Thus, in certain situations, the `.flexGrow` property must be manually applied to the containers. Two common examples of this that we see include:
 
-<ul>
-  <li>a node (with flexGrow enabled) is wrapped in a static layoutSpec, wrapped in a stack layoutSpec. <b>solution</b>: enable flexGrow on the static layotuSpec as well.</li>
-  <li>a node (with flexGrow enabled) is wrapped in an inset spec. <b>solution</b>: enable flexGrow on the inset spec as well.</li>
-</ul>
+- a node (with `flexGrow` enabled) is wrapped in a static layoutSpec, wrapped in a stack layoutSpec. **solution**: enable `flexGrow` on the static layoutSpec as well.
+- a node (with `flexGrow` enabled) is wrapped in an inset spec. **solution**: enable `flexGrow` on the inset spec as well.
+
 
 #### I want to provide a size for my image, but I don't want to hard code the size.
 
@@ -189,9 +187,6 @@ An inset spec requires its object to have an intrinsic size. It adds the inset p
 <img src="/static/images/overlay-vs-inset-spec.png">
 
 ### Best Practices
-<ul>
-  <li>AsyncDisplayKit layout is called on a background thread. Do not access the device screen bounds, or any other UIKit methods in `layoutSpecThatFits:`.</li>
-  <li>don't wrap everything in a staticLayoutSpec?</li>
-  <li>avoid using preferred frame size for everything - won't respond nicely to device rotation or device sizing differences?</li>
-</ul>
-
+  - AsyncDisplayKit layout is called on a background thread. Do not access the device screen bounds, or any other UIKit methods in `layoutSpecThatFits:`.
+  - don't wrap everything in a staticLayoutSpec?
+  - avoid using preferred frame size for everything - won't respond nicely to device rotation or device sizing differences?

--- a/docs/_docs/control-node.md
+++ b/docs/_docs/control-node.md
@@ -15,9 +15,9 @@ This fact is especially useful when it comes to image and text nodes.  Having th
 Like <code>UIControl</code>, <code>ASControlNode</code> has a state which defines its appearance and ability to support user interactions.  Its state can be one of any state defined by <code>ASControlState</code>.
 
 <div class = "highlight-group">
-<span class="language-toggle"><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
-  <pre lang="objc" class="objcCode">
+<pre lang="objc" class="objcCode">
 typedef NS_OPTIONS(NSUInteger, ASControlState) {
     ASControlStateNormal       = 0,
     ASControlStateHighlighted  = 1 << 0,  // used when isHighlighted is set
@@ -25,7 +25,15 @@ typedef NS_OPTIONS(NSUInteger, ASControlState) {
     ASControlStateSelected     = 1 << 2,  // used when isSelected is set
     ...
 };
-  </pre>
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+public struct ASControlState : OptionSet {
+    public static var highlighted: ASControlState { get } // used when ASControlNode isHighlighted is set
+    public static var disabled: ASControlState { get }
+    public static var selected: ASControlState { get } // used when ASControlNode isSelected is set
+    public static var reserved: ASControlState { get } // flags reserved for internal framework use
+}
+</pre>
 </div>
 </div>
 
@@ -35,7 +43,7 @@ Also similarly to <code>UIControl</code>, <code>ASControlNode</code>'s have a se
 
 The available actions are: 
 <div class = "highlight-group">
-<span class="language-toggle"><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
   <pre lang="objc" class="objcCode">
 typedef NS_OPTIONS(NSUInteger, ASControlNodeEvent)
@@ -58,6 +66,28 @@ typedef NS_OPTIONS(NSUInteger, ASControlNodeEvent)
   ASControlNodeEventAllEvents         = 0xFFFFFFFF
 };
 </pre>
+<pre lang="swift" class = "swiftCode hidden">
+public struct ASControlNodeEvent : OptionSet {
+    /** A touch-down event in the control node. */
+    public static var touchDown: ASControlNodeEvent { get }
+    /** A repeated touch-down event in the control node; for this event the value of the UITouch tapCount method is greater than one. */
+    public static var touchDownRepeat: ASControlNodeEvent { get }
+    /** An event where a finger is dragged inside the bounds of the control node. */
+    public static var touchDragInside: ASControlNodeEvent { get }
+    /** An event where a finger is dragged just outside the bounds of the control. */
+    public static var touchDragOutside: ASControlNodeEvent { get }
+    /** A touch-up event in the control node where the finger is inside the bounds of the node. */
+    public static var touchUpInside: ASControlNodeEvent { get }
+    /** A touch-up event in the control node where the finger is outside the bounds of the node. */
+    public static var touchUpOutside: ASControlNodeEvent { get }
+    /** A system event canceling the current touches for the control node. */
+    public static var touchCancel: ASControlNodeEvent { get }
+    /** A system event when the Play/Pause button on the Apple TV remote is pressed. */
+    public static var primaryActionTriggered: ASControlNodeEvent { get }
+    /** All events, including system events. */
+    public static var allEvents: ASControlNodeEvent { get }
+}
+</pre>
 </div>
 </div>
 
@@ -76,12 +106,12 @@ CGFloat verticalDiff = (bounds.size.height - _playButton.bounds.size.height)/2;
 
 _playButton.hitTestSlop = UIEdgeInsetsMake(-verticalDiff, -horizontalDiff, -verticalDiff, -horizontalDiff);
 </pre>
-<!-- <pre lang="swift" class = "swiftCode hidden">
-let horizontalDiff: CGFloat = (bounds.size.width - playButton.bounds.size.width)/2.0
-let verticalDiff: CGfloat   = (bounds.size.height - playButton.bounds.size.height)/2.0
+<pre lang="swift" class = "swiftCode hidden">
+let horizontalDiff = (bounds.size.width - playButton.bounds.size.width) / 2
+let verticalDiff = (bounds.size.height - playButton.bounds.size.height) / 2
 
 playButton.hitTestSlop = UIEdgeInsets(top: -verticalDiff, left: -horizontalDiff, bottom: -verticalDiff, right: -horizontalDiff)
-</pre> -->
+</pre>
 </div>
 </div>
 

--- a/docs/_docs/editable-text-node.md
+++ b/docs/_docs/editable-text-node.md
@@ -84,9 +84,13 @@ In order to respond to events associated with an editable text node, you can use
 --  Indicates to the delegate that the text node began editing.
 
 <div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
 - (void)editableTextNodeDidBeginEditing:(ASEditableTextNode *)editableTextNode;
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+optional public func editableTextNodeDidBeginEditing(_ editableTextNode: ASEditableTextNode)
 </pre>
 </div>
 </div>
@@ -94,9 +98,13 @@ In order to respond to events associated with an editable text node, you can use
 --  Asks the delegate whether the specified text should be replaced in the editable text node.
 
 <div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
 - (BOOL)editableTextNode:(ASEditableTextNode *)editableTextNode shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text;
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+optional public func editableTextNode(_ editableTextNode: ASEditableTextNode, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool
 </pre>
 </div>
 </div>
@@ -104,9 +112,13 @@ In order to respond to events associated with an editable text node, you can use
 --  Indicates to the delegate that the text node's selection has changed.
 
 <div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
 - (void)editableTextNodeDidChangeSelection:(ASEditableTextNode *)editableTextNode fromSelectedRange:(NSRange)fromSelectedRange toSelectedRange:(NSRange)toSelectedRange dueToEditing:(BOOL)dueToEditing;
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+optional public func editableTextNodeDidChangeSelection(_ editableTextNode: ASEditableTextNode, fromSelectedRange: NSRange, toSelectedRange: NSRange, dueToEditing: Bool)
 </pre>
 </div>
 </div>
@@ -114,9 +126,13 @@ In order to respond to events associated with an editable text node, you can use
 --  Indicates to the delegate that the text node's text was updated.
 
 <div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
 - (void)editableTextNodeDidUpdateText:(ASEditableTextNode *)editableTextNode;
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+optional public func editableTextNodeDidUpdateText(_ editableTextNode: ASEditableTextNode)
 </pre>
 </div>
 </div>
@@ -124,9 +140,13 @@ In order to respond to events associated with an editable text node, you can use
 --  Indicates to the delegate that teh text node has finished editing.
 
 <div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
 <div class = "code">
 <pre lang="objc" class="objcCode">
 - (void)editableTextNodeDidFinishEditing:(ASEditableTextNode *)editableTextNode;
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+optional public func editableTextNodeDidFinishEditing(_ editableTextNode: ASEditableTextNode)
 </pre>
 </div>
 </div>

--- a/docs/_docs/layout-api-sizing.md
+++ b/docs/_docs/layout-api-sizing.md
@@ -26,39 +26,73 @@ Note that .flexBasis can be set on any &ltASLayoutable&gt (a node, or a layout s
 <br>
 `ASDimension.h` contains 3 convenience functions to construct an `ASRelativeDimension`.  It is easiest to use function that corresponds to the type (top 2 functions).
 
-``` 
-    ASRelativeDimensionMakeWithPoints(CGFloat points);
-    ASRelativeDimensionMakeWithPercent(CGFloat percent);
-    ASRelativeDimensionMake(ASRelativeDimensionType type, CGFloat value);
-```
+<div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+
+<div class = "code">
+<pre lang="objc" class="objcCode">
+ASRelativeDimensionMakeWithPoints(CGFloat points);
+ASRelativeDimensionMakeWithPercent(CGFloat percent);
+ASRelativeDimensionMake(ASRelativeDimensionType type, CGFloat value);
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+public func ASDimensionMake(_ points: CGFloat) -> ASDimension
+public func ASDimensionMakeWithFraction(_ fraction: CGFloat) -> ASDimension
+public func ASDimensionMake(_ unit: ASDimensionUnit, _ value: CGFloat)
+</pre>
+</div>
+</div>
+
 #### ASRelativeDimension Example
 <br>
 `PIPlaceSingleDetailNode` uses flexBasis to set 2 child nodes of a horizontal stack to share the width 40 / 60:
 
-```
-    leftSideStack.flexBasis = ASRelativeDimensionMakeWithPercent(0.4f);
-    self.detailLabel.flexBasis  = ASRelativeDimensionMakeWithPercent(0.6f);
-    [horizontalStack setChildren:@[leftSideStack, self.detailLabel]];
-```
+<div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+
+<div class = "code">
+<pre lang="objc" class="objcCode">
+leftSideStack.flexBasis = ASRelativeDimensionMakeWithPercent(0.4f);
+self.detailLabel.flexBasis  = ASRelativeDimensionMakeWithPercent(0.6f);
+[horizontalStack setChildren:@[leftSideStack, self.detailLabel]];
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+leftSideStack.style.flexBasis = ASDimensionMake("40%")
+detailsLabel.style.flexBasis = ASDimensionMake("60%")
+horizontalStack.children = [leftSideStack, detailsLabel]
+</pre>
+</div>
+</div>
 
 <img src="/static/images/flexbasis.png" width="40%" height="40%">
 
 ## Sizes (CGSize,  ASRelativeSize)
 <br>
-`ASRelativeSize` is **similar to a CGSize, but its width and height may represent either a point or percent value.**  In fact, their unit type may even be different from one another. ASRelativeSize doesn't have a direct use in the Layout API, except to construct an ASRelativeSizeRange.
+`ASRelativeSize` is **similar to a CGSize, but its width and height may represent either a point or percent value.**  In fact, their unit type may even be different from one another. `ASRelativeSize` doesn't have a direct use in the Layout API, except to construct an `ASRelativeSizeRange`.
 
-- an ASRelativeSize consists of a `.width` and `.height` that are each `ASRelativeDimensions`. 
+- an `ASRelativeSize` consists of a `.width` and `.height` that are each `ASRelativeDimensions`. 
 
 - the type of the width and height are independent; either one individually, or both, may be a point or percent value. (e.g. you could specify that an ASRelativeSize that has a height in points, but a variable % width)
 
 #### Constructing ASRelativeSizes
 <br>
-`ASRelativeSize.h` contains 2 convenience functions to construct an `ASRelativeSize`.  **If you don't need to support relative (%) values, you can construct an ASRelativeSize with just a CGSize.**
+`ASRelativeSize.h` contains 2 convenience functions to construct an `ASRelativeSize`.  **If you don't need to support relative (%) values, you can construct an `ASRelativeSize` with just a CGSize.**
 
-``` 
-    ASRelativeSizeMake(ASRelativeDimension width, ASRelativeDimension height);
-    ASRelativeSizeMakeWithCGSize(CGSize size);
-```
+<div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+
+<div class = "code">
+<pre lang="objc" class="objcCode">
+ASRelativeSizeMake(ASRelativeDimension width, ASRelativeDimension height);
+ASRelativeSizeMakeWithCGSize(CGSize size);
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+ASLayoutSize(width: ASDimension, height: ASDimension)
+// ASRelativeSizeMakeWithCGSize deprecated in swift
+</pre>
+</div>
+</div>
+
 ## Size Ranges (ASSizeRange, ASRelativeSizeRange)
 
 Because the layout spec system allows flexibility with elements growing and shrinking, we sometimes need to provide limits / boundaries to its flexibility.
@@ -73,11 +107,20 @@ In the Pinterest code base, the **minimum size seems to be only necessary for st
 <br>
 UIKit doesn't provide a structure to bundle a minimum and maximum CGSize.  So `ASSizeRange` was created to support **a minimum and maximum CGSize pair**. 
 
-The `constrainedSize` that is passed as an input to `layoutSpecThatFits:` is an ASSizeRange. 
+The `constrainedSize` that is passed as an input to `layoutSpecThatFits:` is an `ASSizeRange`. 
 
-```
-    - (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize;
-```
+<div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+
+<div class = "code">
+<pre lang="objc" class="objcCode">
+- (ASLayoutSpec *)layoutSpecThatFits:(ASSizeRange)constrainedSize;
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+open func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec
+</pre>
+</div>
+</div>
 
 #### ASRelativeSizeRange
 <br>
@@ -101,13 +144,22 @@ Why do we pass a `ASSizeRange *constrainedSize` to a node's `layoutSpecThatFits:
 
 - Percentage and point values can be combined. E.g. you could specify that an object is a certain height in points, but a variable percentage width. 
 
-- If you only care to constrain the min / max or width / height, you can pass in CGFLOAT_MIN, CGFLOAT_MAX, constrainedSize.max.width, etc
+- If you only care to constrain the min / max or width / height, you can pass in `CGFLOAT_MIN`, `CGFLOAT_MAX`, `constrainedSize.max.width`, etc
 
 Most of the time, relative values are not needed for a size range _and_ the design requires an object to be forced to a particular size (min size = max size = no range). In this common case, you can use:
 
-```
-    ASRelativeSizeRangeMakeWithExactCGSize(CGSize exact);
-```
+<div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+
+<div class = "code">
+<pre lang="objc" class="objcCode">
+ASRelativeSizeRangeMakeWithExactCGSize(CGSize exact);
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+public func ASSizeRangeMake(_ exactSize: CGSize) -> ASSizeRange
+</pre>
+</div>
+</div>
 
 ### Sizing Conclusion
 <br>

--- a/docs/_docs/layout-transition-api.md
+++ b/docs/_docs/layout-transition-api.md
@@ -30,6 +30,7 @@ The internal layout spec of the `SignupNode` container would look something like
 
 <div class = "highlight-group">
 <span class="language-toggle">
+  <a data-lang="swift" class="swiftButton">Swift</a>
   <a data-lang="objective-c" class = "active objcButton">Objective-C</a>
 </span>
 <div class = "code">
@@ -50,6 +51,23 @@ The internal layout spec of the `SignupNode` container would look something like
   return [ASInsetLayoutSpec insetLayoutSpecWithInsets:insets child:stack];
 }
 </pre>
+<pre lang="swift" class = "swiftCode hidden">
+override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+  let fieldNode: FieldNode
+  
+  if self.fieldState == .signupNodeName {
+      fieldNode = self.nameField
+  } else {
+      fieldNode = self.ageField
+  }
+  
+  let stack = ASStackLayoutSpec()
+  stack.children = [fieldNode, buttonNode]
+  
+  let insets = UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15)
+  return ASInsetLayoutSpec(insets: insets, child: stack)
+}
+</pre>
 </div>
 </div>
 
@@ -59,6 +77,7 @@ This method will invalidate the current calculated layout and recompute a new la
 
 <div class = "highlight-group">
 <span class="language-toggle">
+  <a data-lang="swift" class="swiftButton">Swift</a>
   <a data-lang="objective-c" class = "active objcButton">Objective-C</a>
 </span>
 <div class = "code">
@@ -66,6 +85,10 @@ This method will invalidate the current calculated layout and recompute a new la
 self.signupNode.fieldState = SignupNodeAge;
 
 [self.signupNode transitionLayoutWithAnimation:YES];
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+self.signupNode.fieldState = .signupNodeName
+self.signupNode.transitionLayout(withAnimation: true, shouldMeasureAsync: true)
 </pre>
 </div>
 </div>
@@ -78,6 +101,7 @@ This method is called after the new layout has been calculated via `transitionLa
 
 <div class = "highlight-group">
 <span class="language-toggle">
+  <a data-lang="swift" class="swiftButton">Swift</a>
   <a data-lang="objective-c" class = "active objcButton">Objective-C</a>
 </span>
 <div class = "code">
@@ -89,12 +113,12 @@ This method is called after the new layout has been calculated via `transitionLa
     initialNameFrame.origin.x += initialNameFrame.size.width;
     self.nameField.frame = initialNameFrame;
     self.nameField.alpha = 0.0;
-    CGRect finalEmailFrame = [context finalFrameForNode:self.nameField];
-    finalEmailFrame.origin.x -= finalEmailFrame.size.width;
+    CGRect finalAgeFrame = [context finalFrameForNode:self.nameField];
+    finalAgeFrame.origin.x -= finalAgeFrame.size.width;
     [UIView animateWithDuration:0.4 animations:^{
       self.nameField.frame = [context finalFrameForNode:self.nameField];
       self.nameField.alpha = 1.0;
-      self.ageField.frame = finalEmailFrame;
+      self.ageField.frame = finalAgeFrame;
       self.ageField.alpha = 0.0;
     } completion:^(BOOL finished) {
       [context completeTransition:finished];
@@ -117,9 +141,48 @@ This method is called after the new layout has been calculated via `transitionLa
   }
 }
 </pre>
+<pre lang="swift" class = "swiftCode hidden">
+override func animateLayoutTransition(_ context: ASContextTransitioning) {
+  if fieldState == .signupNodeName {
+    let initialNameFrame = context.initialFrame(for: ageField)
+    
+    nameField.frame = initialNameFrame
+    nameField.alpha = 0
+    
+    var finalAgeFrame = context.finalFrame(for: nameField)
+    finalAgeFrame.origin.x -= finalAgeFrame.size.width
+    
+    UIView.animate(withDuration: 0.4, animations: { 
+        self.nameField.frame = context.finalFrame(for: self.nameField)
+        self.nameField.alpha = 1
+        self.ageField.frame = finalAgeFrame
+        self.ageField.alpha = 0
+    }, completion: { finished in
+        context.completeTransition(finished)
+    })
+  } else {
+    var initialAgeFrame = context.initialFrame(for: nameField)
+    initialAgeFrame.origin.x += initialAgeFrame.size.width
+    
+    ageField.frame = initialAgeFrame
+    ageField.alpha = 0
+    
+    var finalNameFrame = context.finalFrame(for: ageField)
+    finalNameFrame.origin.x -= finalNameFrame.size.width
+    
+    UIView.animate(withDuration: 0.4, animations: { 
+        self.ageField.frame = context.finalFrame(for: self.ageField)
+        self.ageField.alpha = 1
+        self.nameField.frame = finalNameFrame
+        self.nameField.alpha = 0
+    }, completion: { finished in
+        context.completeTransition(finished)
+    })
+  }
+}
+</pre>
 </div>
 </div>
-
 
 The passed <a href="https://github.com/facebook/AsyncDisplayKit/blob/master/AsyncDisplayKit/ASContextTransitioning.h"><code>ASContextTransitioning</code></a> context object in this method contains relevant information to help you determine the state of the nodes before and after the transition. It includes getters into old and new constrained sizes, inserted and removed nodes, and even the raw old and new `ASLayout` objects. In the `SignupNode` example, we're using it to determine the frame for each of the fields and animate them in an out of place.
 
@@ -133,6 +196,7 @@ Passing NO to `transitionLayoutWithAnimation:` will still run through your `anim
 
 <div class = "highlight-group">
 <span class="language-toggle">
+  <a data-lang="swift" class="swiftButton">Swift</a>
   <a data-lang="objective-c" class = "active objcButton">Objective-C</a>
 </span>
 <div class = "code">
@@ -143,6 +207,15 @@ Passing NO to `transitionLayoutWithAnimation:` will still run through your `anim
     // perform animation
   } else {
     [super animateLayoutTransition:context];
+  }
+}
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+override func animateLayoutTransition(_ context: ASContextTransitioning) {
+  if context.isAnimated() {
+      
+  } else {
+      super.animateLayoutTransition(contet)
   }
 }
 </pre>
@@ -157,6 +230,7 @@ This method is similar to `transitionLayoutWithAnimation:`, but will not trigger
 
 <div class = "highlight-group">
 <span class="language-toggle">
+  <a data-lang="swift" class="swiftButton">Swift</a>
   <a data-lang="objective-c" class = "active objcButton">Objective-C</a>
 </span>
 <div class = "code">
@@ -167,6 +241,14 @@ This method is similar to `transitionLayoutWithAnimation:`, but will not trigger
   [coordinator animateAlongsideTransition:^(id&lt;UIViewControllerTransitionCoordinatorContext&gt;  _Nonnull context) {
     [self.node transitionLayoutWithSizeRange:ASSizeRangeMake(size, size) animated:YES];
   } completion:nil];
+}
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+  super.viewWillTransition(to: size, with: coordinator)
+  coordinator.animate(alongsideTransition: { context in
+      self.node.transitionLayout(with: ASSizeRange(min: size, max: size), animated: true, shouldMeasureAsync: true)
+  })
 }
 </pre>
 </div>

--- a/docs/_docs/subclassing.md
+++ b/docs/_docs/subclassing.md
@@ -55,7 +55,12 @@ This method is called once, at the very begining of an ASViewController's lifecy
 
 ASViewController's designated initializer is `initWithNode:`. A typical initializer will look something like the code below. Note how the ASViewController's node is created _before_ calling super. An ASViewController manages a node similarly to how a UIViewController manages a view, but the initialization is slightly different. 
 
-``` 
+
+<div class = "highlight-group">
+<span class="language-toggle"><a data-lang="swift" class="swiftButton">Swift</a><a data-lang="objective-c" class = "active objcButton">Objective-C</a></span>
+
+<div class = "code">
+<pre lang="objc" class="objcCode">
 - (instancetype)init
 {
   _pagerNode = [[ASPagerNode alloc] init];
@@ -69,7 +74,18 @@ ASViewController's designated initializer is `initWithNode:`. A typical initiali
   
   return self;
 }
-```
+</pre>
+<pre lang="swift" class = "swiftCode hidden">
+init() {
+  let pagerNode = ASPagerNode()
+  super.init(node: pagerNode)
+
+  pagerNode.setDataSource(self)
+  pagerNode.setDelegate(self)
+}
+</pre>
+</div>
+</div>
        
 ### `-loadView`
 


### PR DESCRIPTION
Several fixes from [2750 issue](https://github.com/facebook/AsyncDisplayKit/issues/2750).

-  http://asyncdisplaykit.org/docs/subclassing.html ASViewController section, sample code doesn’t have syntax highlighting & swift example
-  http://asyncdisplaykit.org/docs/control-node.html none example have swift version
-  http://asyncdisplaykit.org/docs/editable-text-node.html ASEditableTextNode Delegate examples
-  http://asyncdisplaykit.org/docs/layout-api-sizing.html syntax highlighting & swift version