### PR TITLE
Fix Compile Error on Swift Sample code.

### DIFF
--- a/docs/_docs/text-node.md
+++ b/docs/_docs/text-node.md
@@ -24,7 +24,7 @@ _node.attributedString = string;
 </pre>
 
 <pre lang="swift" class = "swiftCode hidden">
-let attrs = [NSFontAttributeName: UIFont(name: "HelveticaNeue", size: "12.0")] 
+let attrs = [NSFontAttributeName: UIFont(name: "HelveticaNeue", size: 12.0)] 
 let string = NSAttributedString(string: "Hey, here's some text.", attributes: attrs)
 
 node = ASTextNode()


### PR DESCRIPTION
In Swift,  the init method for UI Font is as follows:
public /*not inherited*/ init?(name fontName: String, size fontSize: CGFloat)

Therefore, it's not appropriate for a string to be here. Developers copying and pasting this will get a compiler error attempting to use it.