### PR TITLE
Make the docs typography more readable

### DIFF
--- a/docs/static/main.css
+++ b/docs/static/main.css
@@ -16,7 +16,7 @@ html {
 body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-weight: 300;
+    font-weight: 400;
     color: #444;
     margin: 0;
     line-height: 22px;


### PR DESCRIPTION
Light font-weights should generally be only used for large type. At smaller font-sizes a normal weight font improves legibility.

Before:

![screen shot 2017-02-09 at 7 45 00 pm](https://cloud.githubusercontent.com/assets/718/22813433/7005e572-ef00-11e6-9f8e-56020529515f.png)

After:

![screen shot 2017-02-09 at 7 44 55 pm](https://cloud.githubusercontent.com/assets/718/22813435/75ce88e2-ef00-11e6-8db7-8ef5af7b4e3f.png)


