### PR TITLE
fixed unescaped <> in asviewcontroller.md

### DIFF
--- a/docs/_docs/asviewcontroller.md
+++ b/docs/_docs/asviewcontroller.md
@@ -32,7 +32,7 @@ Consider the following `ASViewController` subclass that would like to use a cust
 </pre>
 
   <pre lang="swift" class = "swiftCode hidden">
-func initWithModel(models: Array<Model>) {
+func initWithModel(models: Array&lt;Model&gt;) {
 	let tableNode = ASTableNode(style:.Plain)
 
     super.initWithNode(tableNode)


### PR DESCRIPTION
the unescaped angle brackets around `<Model>` distorts the html when the Swift example of [this page](http://asyncdisplaykit.org/docs/asviewcontroller.html) is shown. this change fixes that.