### PR TITLE
[ASCellNode] Update Swift example & Replace deprecated preferredFrameSize.

### DIFF
--- a/docs/_docs/cell-node.md
+++ b/docs/_docs/cell-node.md
@@ -48,12 +48,12 @@ For example, say you already have a view controller written that manages an `AST
 }
 </pre>
 <pre lang="swift" class = "swiftCode hidden">
-func pagerNode(pagerNode: ASPagerNode!, nodeAtIndex index: Int) -> ASCellNode! {
+func pagerNode(_ pagerNode: ASPagerNode, nodeAt index: Int) -> ASCellNode {
     let animals = allAnimals[index]
     
     let node = ASCellNode(viewControllerBlock: { () -> UIViewController in
         return AnimalTableNodeController(animals: animals)
-    }, didLoadBlock: nil)
+    }, didLoad: nil)
     
     node.preferredFrameSize = pagerNode.bounds.size
     
@@ -92,7 +92,7 @@ Alternatively, if you already have a `UIView` or `CALayer` subclass that you'd l
 }
 </pre>
 <pre lang="swift" class = "swiftCode hidden">
-func pagerNode(pagerNode: ASPagerNode!, nodeAtIndex index: Int) -> ASCellNode! {
+func pagerNode(_ pagerNode: ASPagerNode, nodeAt index: Int) -> ASCellNode {
     let animal = animals[index]
     
     let node = ASCellNode { () -> UIView in

--- a/docs/_docs/cell-node.md
+++ b/docs/_docs/cell-node.md
@@ -42,7 +42,7 @@ For example, say you already have a view controller written that manages an `AST
         return [[AnimalTableNodeController alloc] initWithAnimals:animals];
     } didLoadBlock:nil];
     
-    node.preferredFrameSize = pagerNode.bounds.size;
+    node.style.preferredSize = pagerNode.bounds.size;
     
     return node;
 }
@@ -55,7 +55,7 @@ func pagerNode(_ pagerNode: ASPagerNode, nodeAt index: Int) -> ASCellNode {
         return AnimalTableNodeController(animals: animals)
     }, didLoad: nil)
     
-    node.preferredFrameSize = pagerNode.bounds.size
+    node.style.preferredSize = pagerNode.bounds.size
     
     return node
 }
@@ -86,7 +86,7 @@ Alternatively, if you already have a `UIView` or `CALayer` subclass that you'd l
         return [[SomeAnimalView alloc] initWithAnimal:animal];
     }];
 
-    node.preferredFrameSize = pagerNode.bounds.size;
+    node.style.preferredSize = pagerNode.bounds.size;
     
     return node;
 }
@@ -99,7 +99,7 @@ func pagerNode(_ pagerNode: ASPagerNode, nodeAt index: Int) -> ASCellNode {
         return SomeAnimalView(animal: animal)
     }
 
-    node.preferredFrameSize = pagerNode.bounds.size
+    node.style.preferredSize = pagerNode.bounds.size
     
     return node
 }


### PR DESCRIPTION
Hey! This PR updates the Swift example for `ASCellNode`. Additionally, I've replaced `node.preferredFrameSize` with `node.style.preferredSize` (also in Obj-C examples), since `preferredFrameSize` is deprecated as of now. 

Cheers! 🎉 