### PR TITLE
Consistent language toggles in ASM doc

### DIFF
--- a/docs/_docs/automatic-subnode-mgmt.md
+++ b/docs/_docs/automatic-subnode-mgmt.md
@@ -181,8 +181,8 @@ Consider the abreviated `layoutSpecThatFits:` method for the `ASCellNode` subcla
 
 <div class = "highlight-group">
 <span class="language-toggle">
-<a data-lang="swift" class="swiftButton">Swift</a>
 <a data-lang="objective-c" class="active objcButton">Objective-C</a>
+<a data-lang="swift" class="swiftButton">Swift</a>
 </span>
 
 <div class = "code">


### PR DESCRIPTION
The last language toggle in http://asyncdisplaykit.org/docs/automatic-subnode-mgmt.html is inconsistent with other toggles above it. This PR should fix that.