### PR TITLE
[ASVideoNode/ASMapNode] Update Swift examples.

### DIFF
--- a/docs/_docs/map-node.md
+++ b/docs/_docs/map-node.md
@@ -18,7 +18,7 @@ Let's say you'd like to show a snapshot of San Francisco.  All you need are the 
 <div class = "code">
 <pre lang="objc" class="objcCode">
 ASMapNode *mapNode = [[ASMapNode alloc] init];
-mapNode.preferredFrameSize = CGSizeMake(300.0, 300.0);
+mapNode.style.preferredSize = CGSizeMake(300.0, 300.0);
 
 // San Francisco
 CLLocationCoordinate2D coord = CLLocationCoordinate2DMake(37.7749, -122.4194);
@@ -29,7 +29,7 @@ mapNode.region = MKCoordinateRegionMakeWithDistance(coord, 20000, 20000);
 
 <pre lang="swift" class = "swiftCode hidden">
 let mapNode = ASMapNode()
-mapNode.preferredFrameSize = CGSize(width: 300.0, height: 300.0)
+mapNode.style.preferredSize = CGSize(width: 300.0, height: 300.0)
 
 // San Francisco
 let coord = CLLocationCoordinate2DMake(37.7749, -122.4194)
@@ -71,7 +71,7 @@ mapNode.options = options;
 </pre>
 <pre lang="swift" class = "swiftCode hidden">
 let options = MKMapSnapshotOptions()
-options.mapType = .Satellite
+options.mapType = .satellite
 options.region = MKCoordinateRegionMakeWithDistance(coord, 20000, 20000)
 
 mapNode.options = options

--- a/docs/_docs/video-node.md
+++ b/docs/_docs/video-node.md
@@ -28,7 +28,7 @@ videoNode.asset = asset;
 <pre lang="swift" class = "swiftCode hidden">
 let videoNode = ASVideoNode()
 
-let asset = AVAsset(URL: NSURL(string: "http://www.w3schools.com/html/mov_bbb.mp4"))
+let asset = AVAsset(url: URL(string: "http://www.w3schools.com/html/mov_bbb.mp4")!)
 videoNode.asset = asset
 </pre>
 </div>
@@ -78,7 +78,7 @@ There are a ton of delegate methods available to you that allow you to react to 
 - (void)videoNode:(ASVideoNode *)videoNode willChangePlayerState:(ASVideoNodePlayerState)state toState:(ASVideoNodePlayerState)toState;
 </pre>
 <pre lang="swift" class = "swiftCode hidden">
-videoNode(videoNode:willChangePlayerState:toState:)
+videoNode(_:willChange:to:)
 </pre>
 </div>
 </div>


### PR DESCRIPTION
Hello! 🎉 

In this PR I've updated Swift examples of `ASVideoNode `/`ASMapNode ` & updated to `style.preferredSize` from `preferredFrameSize` in both `ObjC`/`Swift` examples. 

For similar reason as in #122, I've merged both of these classes into one PR because in `ASVideoNode` there wasn't many changes and I think it is still clear what has changed.